### PR TITLE
証明書のパスとtls設定の一部変更

### DIFF
--- a/debug/tls-server.go
+++ b/debug/tls-server.go
@@ -12,7 +12,7 @@ import (
 
 // https://gist.github.com/denji/12b3a568f092ab951456
 func main() {
-	cert, err := tls.LoadX509KeyPair("./my-tls.pem", "./my-tls-key.pem")
+	cert, err := tls.LoadX509KeyPair("./my-tls.com+2.pem", "./my-tls.com+2-key.pem")
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -21,7 +21,7 @@ func main() {
 	config := &tls.Config{
 		Certificates: []tls.Certificate{cert},
 		Rand:         utils.ZeroSource{}, // for example only; don't do this.
-		MinVersion:   tls.VersionTLS13,
+		MinVersion:   tls.VersionTLS12,
 		MaxVersion:   tls.VersionTLS13,
 		CipherSuites: []uint16{tls.TLS_RSA_WITH_AES_128_GCM_SHA256},
 		//CurvePreferences: []tls.CurveID{tls.X25519},


### PR DESCRIPTION
初めまして！sat0kenさんの書籍や記事をいつも参考にさせて頂いています🙇
私もTLS1.2の実装をしてみたく、https://zenn.dev/satoken/articles/golang-tls1_2 の記事を拝読しており、少し変更を加えた方が良さそうと思いPRを出してみました！

変更箇所は、上記記事の[下準備](https://zenn.dev/satoken/articles/golang-tls1_2#%E4%B8%8B%E6%BA%96%E5%82%99) で紹介されているコードです

- mkcert で生成される証明書のパス
- サポートするTLSの最小のversion
  - `MinVersion:   tls.VersionTLS13,` ですと、以下のエラーでServerHello以降が返ってこなかったので変更しました🙇

```console
16:05:48 > echo | openssl s_client -4 -tls1_2 -cipher AES128-GCM-SHA256 -connect 127.0.0.1:10443
Connecting to 127.0.0.1
CONNECTED(00000003)
803B5DBEF07F0000:error:0A00042E:SSL routines:ssl3_read_bytes:tlsv1 alert protocol version:ssl/record/rec_layer_s3.c:865:SSL alert number 70
---
no peer certificate available
---
No client certificate CA names sent
---
SSL handshake has read 7 bytes and written 118 bytes
Verification: OK
---
New, (NONE), Cipher is (NONE)
Secure Renegotiation IS NOT supported
Compression: NONE
Expansion: NONE
No ALPN negotiated
SSL-Session:
    Protocol  : TLSv1.2
    Cipher    : 0000
    Session-ID:
    Session-ID-ctx:
    Master-Key:
    PSK identity: None
    PSK identity hint: None
    SRP username: None
    Start Time: 1721459216
    Timeout   : 7200 (sec)
    Verify return code: 0 (ok)
    Extended master secret: no
---
~
16:06:56 > echo $?
1
~
16:07:23 >
```

記事に大変たすかっております。ありがとうございます！